### PR TITLE
Fix course detail page and content components

### DIFF
--- a/app/[locale]/(protected)/courses/[courseSlug]/_components/course-content.tsx
+++ b/app/[locale]/(protected)/courses/[courseSlug]/_components/course-content.tsx
@@ -28,16 +28,24 @@ export interface CourseContentProps {
       }[];
     }[];
   }[];
+  // Lessons that are attached directly to the course (no chapter/module)
+  lessons?: {
+    id: string;
+    title: string;
+    slug: string;
+    order: number;
+  }[];
 }
 
-export function CourseContent({ courseSlug, modules }: CourseContentProps) {
+export function CourseContent({ courseSlug, modules, lessons = [] }: CourseContentProps) {
   return (
     <Card className="mt-6 shadow-lg">
       <CardHeader>
-        <CardTitle className="text-2xl font-bold">Course Syllabus</CardTitle>
+        <CardTitle className="text-2xl font-bold">Course Content</CardTitle>
       </CardHeader>
-      <CardContent className="px-4 md:px-6 pb-6">
-        {modules.length > 0 ? (
+      <CardContent className="px-4 md:px-6 pb-6 space-y-6">
+        {/* Render hierarchical syllabus when modules exist */}
+        {modules.length > 0 && (
           <Accordion type="multiple" defaultValue={modules.map((mod) => mod.slug)} className="w-full space-y-2">
             {modules.map((mod) => (
               <AccordionItem
@@ -74,7 +82,32 @@ export function CourseContent({ courseSlug, modules }: CourseContentProps) {
               </AccordionItem>
             ))}
           </Accordion>
-        ) : (
+        )}
+
+        {/* Render top-level lessons when provided */}
+        {lessons.length > 0 && (
+          <div className="space-y-2">
+            {modules.length === 0 && (
+              <h3 className="font-semibold flex items-center gap-2 text-lg">
+                <Folder className="h-4 w-4 text-primary/70" /> Lessons
+              </h3>
+            )}
+            <div className="space-y-1 pl-1">
+              {lessons.sort((a, b) => a.order - b.order).map((lesson) => (
+                <Link
+                  key={lesson.id}
+                  href={`/courses/${courseSlug}/lessons/${lesson.id}/${lesson.slug}`}
+                  className="flex items-center gap-2 py-1 hover:text-primary"
+                >
+                  <BookOpen className="h-4 w-4 text-primary/70" />
+                  <span className="text-sm truncate">{lesson.title}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {modules.length === 0 && lessons.length === 0 && (
           <p className="text-muted-foreground text-center py-4">
             The structure for this course has not been defined yet.
           </p>

--- a/lib/actions/course-actions.ts
+++ b/lib/actions/course-actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { getEnhancedPrisma } from "@/lib/db/enhanced";
+
+/**
+ * Fetch a single course (by slug) together with its syllabus hierarchy and
+ * any lessons that are attached directly to the course (i.e. have no module / chapter).
+ */
+export async function getCourseDetail(courseSlug: string) {
+  const db = await getEnhancedPrisma();
+
+  return db.course.findUnique({
+    where: { slug: courseSlug },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      slug: true,
+      createdAt: true,
+      updatedAt: true,
+      // Hierarchical syllabus (modules -> chapters -> lessons)
+      modules: {
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          order: true,
+          chapters: {
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              order: true,
+              lessons: {
+                select: {
+                  id: true,
+                  title: true,
+                  slug: true,
+                  order: true,
+                },
+                orderBy: { order: "asc" },
+              },
+            },
+            orderBy: { order: "asc" },
+          },
+        },
+        orderBy: { order: "asc" },
+      },
+      // Top-level lessons that do **not** belong to a chapter (chapterId is null)
+      lessons: {
+        where: { chapterId: null },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          order: true,
+        },
+        orderBy: { order: "asc" },
+      },
+      enrollments: {
+        select: { userId: true },
+      },
+      author: { select: { id: true, name: true, image: true } },
+    },
+  });
+} 

--- a/schema.zmodel
+++ b/schema.zmodel
@@ -388,8 +388,6 @@ model Course {
   slug        String             @unique
   joinCode    String?            @unique  // Unique code for students to join the course
   
-  // New field for course structure/hierarchy
-  // structure   Json?       // (Deprecated – use modules/chapters instead)
   modules     CourseModule[]
   
   // Metadata


### PR DESCRIPTION
- Remove deprecated course structure field from schema.
- Simplify course detail fetching by introducing getCourseDetail function.
- Update CourseContent component to handle lessons directly attached to the course.
- Improve lesson count calculation and first lesson determination logic.
- Enhance UI to display lessons when no modules are present.